### PR TITLE
docs: add make and g++ packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ See [Releases](https://github.com/davidbailey00/notion-deb-builder/releases)
    npm -g install asar electron-packager electron-installer-debian
    ```
 
-3. Install packages required for `7z`, `convert`, `fakeroot` and `dpkg`.
+3. Install packages required for `7z`, `convert`, `fakeroot`, make, `g++` and `dpkg`.
 
    Using Ubuntu or Debian:
 
    ```sh
-   sudo apt install p7zip-full imagemagick fakeroot
+   sudo apt install p7zip-full imagemagick fakeroot make g++
    ```
 
    Or, using macOS:

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ check-command() {
 
 commands=(
   node npm asar electron-packager electron-installer-debian
-  7z convert fakeroot dpkg
+  7z convert fakeroot dpkg g++ make
 )
 
 for command in "${commands[@]}"; do


### PR DESCRIPTION
Ubuntu doesn't come with make or g++ installed by default

`dpkg` is mentioned in the package list but is not present in the command. I don't remember if I added it previously on my machine or not, so I didn't touch it.