### PR TITLE
Notion-Enhancer compatibility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,8 @@ if ! [ -d build/dist ]; then
     --arch x64 \
     --out build/dist \
     --electron-version $ELECTRON_VERSION \
-    --executable-name notion-desktop
+    --executable-name notion-desktop \
+    --asar
 fi
 
 # Create Debian package
@@ -123,4 +124,6 @@ electron-installer-debian \
   --dest out \
   --arch amd64 \
   --options.productName Notion \
-  --options.icon build/dist/app-linux-x64/resources/app/icon.png
+  --options.icon build/app/icon.png \
+  --asar=true
+


### PR DESCRIPTION
[Notion-Enhancer](https://github.com/dragonwocky/notion-enhancer) is a popular and awesome mod loader for Notion that supports themes, right-to-left text flow, emoji sets, word counts, and a lot more. It unfortunately does not work with this installation method because it requires the application files to be bundled in an asar file. This can be done with a few trivial changes to the build script and results in no user facing changes whatsoever. 

With these changes in place notion-enhancer works with this installation method.