### PR TITLE
Implement build steps in Earthfile

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,19 @@
+
+deps:
+    FROM node:15
+    COPY build.sh .
+    RUN apt update && \
+        apt -y install p7zip-full imagemagick fakeroot wget python3 make && \
+        npm -g install asar electron-packager electron-installer-debian
+
+build-win:
+    FROM +deps
+    RUN wget 'https://desktop-release.notion-static.com/Notion%20Setup%202.0.8.exe' -O notion.exe && \
+        ./build.sh win
+    SAVE ARTIFACT out/notion-desktop_2.0.8-win_amd64.deb AS LOCAL notion-desktop_2.0.8-win_amd64.deb
+
+build-mac:
+    FROM +deps
+    RUN wget 'https://desktop-release.notion-static.com/Notion-2.0.7.dmg' -O notion.dmg && \
+        ./build.sh mac
+    SAVE ARTIFACT out/notion-desktop_2.0.7-mac_amd64.deb AS LOCAL notion-desktop_2.0.7-mac_amd64.deb

--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ Run the build script:
 replacing `<platform>` with either `win` or `mac`, depending on which sources you would like to build from.
 
 Once complete, you should have a DEB package in the `out` directory.
+
+## Build using Earthly
+
+As an alternative to installing the tooling on your system, you can build the `deb` using [Earthly](https://docs.earthly.dev/installation) and [Docker](https://docs.docker.com/get-docker/).
+
+Once these tools are installed, simply run `earth +build-win` or `earth +build-mac`; depending on which source you want to use. The `deb` will be in your current directory. One advantage is that this eliminates any differences in other environments, and may provide an easier installation process.


### PR DESCRIPTION
This follows your build steps, but using a tool called [Earthly](https://earthly.dev/). This makes it so people don't have to install all the tools, and unhides some dependencies like `make` and `python`.

I found this useful, since I am not a JS guy, and didn't want to install all those packages directly on my machine. I thought it might be useful for you too, since it could help you isolate the environment used to build this `deb`.

Thanks for your script! It certainly helped this Linux Notion user!